### PR TITLE
Added image keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -330,7 +330,7 @@ export default class SmartGallery extends PureComponent {
                             onDoubleTapEndReached(transform, index);
                     }}
                     ref={(ref) => { this.imageRefs.set(index, ref); }}
-                    key={"innerImage#" + index}
+                    key={`innerImage#${item.key || index}`}
                     errorComponent={errorComponent}
                     imageComponent={renderItem}
                     image={item}


### PR DESCRIPTION
When you add images to beginning of data being passed to gallery ImageTransformer state persists previously defined source because key is positional. With unique keys you can avoid that issue